### PR TITLE
feat: added listener for Merged Asset events

### DIFF
--- a/module/pom.xml
+++ b/module/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>asset-client</artifactId>
             <version>${uvms.asset.version}</version>
         </dependency>
+        <dependency>
+            <groupId>fish.focus.uvms.asset</groupId>
+            <artifactId>asset-model</artifactId>
+            <version>${uvms.asset.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>fish.focus.uvms.lib</groupId>
@@ -175,6 +180,12 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/module/src/main/java/fish/focus/uvms/movementrules/service/message/consumer/MergedAssetEventConsumer.java
+++ b/module/src/main/java/fish/focus/uvms/movementrules/service/message/consumer/MergedAssetEventConsumer.java
@@ -1,0 +1,63 @@
+package fish.focus.uvms.movementrules.service.message.consumer;
+
+import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
+import fish.focus.uvms.commons.date.JsonBConfigurator;
+import fish.focus.uvms.movementrules.service.dao.RulesDao;
+import fish.focus.uvms.movementrules.service.entity.PreviousReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.inject.Inject;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+import javax.json.bind.Jsonb;
+
+import static fish.focus.uvms.commons.message.api.MessageConstants.*;
+
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = DESTINATION_TYPE_TOPIC),
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = EVENT_STREAM_TOPIC),
+        @ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = DURABLE_CONNECTION),
+        @ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "movement-rules-merged-asset"),
+        @ActivationConfigProperty(propertyName = "clientId", propertyValue = "movement-rules-merged-asset"),
+        @ActivationConfigProperty(propertyName = "messageSelector", propertyValue = EVENT_STREAM_EVENT + "='Merged Asset'")
+})
+public class MergedAssetEventConsumer implements MessageListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MergedAssetEventConsumer.class);
+
+    @Inject
+    private RulesDao rulesDao;
+
+    private Jsonb jsonb;
+
+    @PostConstruct
+    public void init() {
+        jsonb = new JsonBConfigurator().getContext(null);
+    }
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            TextMessage textMessage = (TextMessage) message;
+            AssetMergeInfo asset = jsonb.fromJson(textMessage.getText(), AssetMergeInfo.class);
+
+            PreviousReport previousReport = rulesDao.getPreviousReportByAssetGuid(asset.getOldAssetId());
+
+            if (previousReport == null) {
+                // don't need to do anything since the asset hadn't been added to the previous report table
+                return;
+            }
+
+            LOG.info("Asset got new ID ({}) -> deleting previous report for asset with old ID {}", asset.getNewAssetId(), asset.getOldAssetId());
+            rulesDao.deletePreviousReport(previousReport);
+        } catch (JMSException e) {
+            LOG.error("Could not handle Merged Asset event message", e);
+        }
+    }
+}

--- a/module/src/test/java/fish/focus/uvms/movementrules/service/message/MergedAssetEventConsumerTest.java
+++ b/module/src/test/java/fish/focus/uvms/movementrules/service/message/MergedAssetEventConsumerTest.java
@@ -1,0 +1,83 @@
+package fish.focus.uvms.movementrules.service.message;
+
+import fish.focus.uvms.asset.remote.dto.AssetMergeInfo;
+import fish.focus.uvms.commons.date.JsonBConfigurator;
+import fish.focus.uvms.movementrules.service.BuildRulesServiceDeployment;
+import fish.focus.uvms.movementrules.service.dao.RulesDao;
+import fish.focus.uvms.movementrules.service.entity.PreviousReport;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.json.bind.Jsonb;
+import java.time.Instant;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.with;
+import static org.hamcrest.CoreMatchers.*;
+
+@RunWith(Arquillian.class)
+public class MergedAssetEventConsumerTest extends BuildRulesServiceDeployment {
+
+    public static final String MERGED_ASSET = "Merged Asset";
+
+    private final Jsonb jsonb = new JsonBConfigurator().getContext(null);
+
+    @Inject
+    private RulesDao rulesDao;
+
+    @Inject
+    private JMSHelper jmsHelper;
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void noOperationWhenNoPreviousReport() {
+        String oldUuid = UUID.randomUUID().toString();
+        // shouldn't have any entries in the previous report table
+        await().until(() -> rulesDao.getPreviousReportByAssetGuid(oldUuid), is(nullValue()));
+
+        String newUuid = UUID.randomUUID().toString();
+        AssetMergeInfo assetMergeInfo = new AssetMergeInfo(oldUuid, newUuid);
+
+        String assetMergedMessage = jsonb.toJson(assetMergeInfo);
+        jmsHelper.sendMessageOnEventStream(assetMergedMessage, MERGED_ASSET);
+
+        with().pollDelay(200, MILLISECONDS).await()
+                .until(() -> rulesDao.getPreviousReportByAssetGuid(oldUuid), is(nullValue()));
+    }
+
+    @Test
+    @OperateOnDeployment("normal")
+    public void removePreviousReportOnMergedAssetEvent() {
+        String oldUuid = UUID.randomUUID().toString();
+
+        PreviousReport previousReport = getBasicPreviousReport(oldUuid);
+        rulesDao.updatePreviousReport(previousReport);
+        await().until(() -> rulesDao.getPreviousReportByAssetGuid(oldUuid), is(notNullValue()));
+
+        String newUuid = UUID.randomUUID().toString();
+        AssetMergeInfo assetMergeInfo = new AssetMergeInfo(oldUuid, newUuid);
+
+        String assetMergedMessage = jsonb.toJson(assetMergeInfo);
+        jmsHelper.sendMessageOnEventStream(assetMergedMessage, MERGED_ASSET);
+
+        await().until(() -> rulesDao.getPreviousReportByAssetGuid(oldUuid), is(nullValue()));
+    }
+
+    private static PreviousReport getBasicPreviousReport(String oldUuid) {
+        PreviousReport previousReport = new PreviousReport();
+
+        previousReport.setAssetGuid(oldUuid);
+        previousReport.setMobTermGuid(UUID.randomUUID());
+        previousReport.setMovementGuid(UUID.randomUUID());
+        previousReport.setPositionTime(Instant.now());
+        previousReport.setUpdated(Instant.now());
+        previousReport.setUpdatedBy(MergedAssetEventConsumerTest.class.getSimpleName());
+
+        return previousReport;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <drools.version>7.73.0.Final</drools.version>
-		
+
         <uvms.pom.version>3.21</uvms.pom.version>
         <exchange.model.version>5.3.30</exchange.model.version>
         <user.model.version>2.2.6</user.model.version>
@@ -23,15 +23,15 @@
         <uvms.config.version>4.1.6</uvms.config.version>
         <usm4uvms.version>4.1.12</usm4uvms.version>
         <uvms.common.version>4.1.15</uvms.common.version>
-        <uvms.asset.version>6.8.32</uvms.asset.version>
+        <uvms.asset.version>6.8.33</uvms.asset.version>
         <uvms.incident.version>1.0.12</uvms.incident.version>
 
 
         <project.scm.id>github</project.scm.id>
         <scm.connection>scm:git:https://github.com/FocusFish/UVMS-MovementRulesModule.git</scm.connection>
-        
+
         <installAtEnd>false</installAtEnd>
-      
+
         <docker.dev.version>4.2.34</docker.dev.version>
         <docker.liquibase.changeLogFile>LIQUIBASE/changelog/db-changelog-master.xml</docker.liquibase.changeLogFile>
         <docker.liquibase.db.user>movementrules</docker.liquibase.db.user>


### PR DESCRIPTION
Now listens for Merged Asset events so it can clean up any related entries in the Previous Report table.

Refs: FART-530