### PR TITLE
test: SSE on subscribe sends two text messages

### DIFF
--- a/module/src/test/java/fish/focus/uvms/movementrules/rest/service/arquillian/SSETestClient.java
+++ b/module/src/test/java/fish/focus/uvms/movementrules/rest/service/arquillian/SSETestClient.java
@@ -13,6 +13,7 @@ package fish.focus.uvms.movementrules.rest.service.arquillian;
 
 import fish.focus.schema.movementrules.ticket.v1.TicketType;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -20,10 +21,15 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.sse.SseEventSource;
 import java.io.Closeable;
 
+import static org.junit.Assert.fail;
+
 public class SSETestClient extends BuildRulesRestDeployment implements Closeable {
 
     private final SseEventSource source;
     private TicketType ticket;
+
+    private int firstTwoMessagesAreStrings = 2;
+    private String failMessage = "";
 
     public SSETestClient() {
         Client client = ClientBuilder.newClient();
@@ -33,21 +39,46 @@ public class SSETestClient extends BuildRulesRestDeployment implements Closeable
         source = SseEventSource.target(jwtTarget).build();
         source.register(inbound -> {
             try {
+                if (firstTwoMessagesAreStrings > 0) {
+                    firstTwoMessagesAreStrings--;
+                    var message = inbound.readData();
+                    if (message == null) {
+                        failMessage = "Got a null SSE message";
+                        return;
+                    }
+                    // two "hello"-type of messages are sent when subscribing
+                    if (!(message.matches("UVMS SSE Ticket notifications") || message.matches("User .* is now registered"))) {
+                        failMessage = "Got unknown SSE Message";
+                        return;
+                    }
+                    return;
+                }
+
                 ticket = inbound.readData(TicketType.class, MediaType.APPLICATION_JSON_TYPE);
-            } catch (Exception e) {
+            } catch (ProcessingException e) {
+                failMessage = "Could not parse the SEE message";
             }
         });
         source.open();
     }
 
     public TicketType getTicketAndReset() {
+        checkFailMessage();
         TicketType returnTicket = ticket;
         ticket = null;
         return returnTicket;
     }
 
     public TicketType getTicket() {
+        checkFailMessage();
         return ticket;
+    }
+
+    private void checkFailMessage() {
+        if (failMessage.isEmpty()) {
+            return;
+        }
+        fail(failMessage);
     }
 
     @Override


### PR DESCRIPTION
Fixed the error message in console for the SSE tests. It was trying to convert the String to TicketType and failing, outputting an error message even though it's expected to receive two "hello"-type of messages.